### PR TITLE
Improve the on* callback type signatures

### DIFF
--- a/example/Example.res
+++ b/example/Example.res
@@ -57,7 +57,9 @@ module Form = {
         render={({field: {name, onBlur, onChange, ref, value}}) =>
           <div>
             <label> {name->React.string} </label>
-            <input name onBlur onChange ref value />
+            <input
+              name onBlur={_event => onBlur()} onChange={Controller.handleEvent(onChange)} ref value
+            />
             <span>
               {errors
               ->Error.get("email")
@@ -80,7 +82,9 @@ module Form = {
         render={({field: {name, onBlur, onChange, ref, value}}) =>
           <div>
             <label> {name->React.string} </label>
-            <input name onBlur onChange ref value />
+            <input
+              name onBlur={_event => onBlur()} onChange={Controller.handleEvent(onChange)} ref value
+            />
             <ErrorMessage errors name message={"Required"->React.string} />
           </div>}
       />
@@ -91,7 +95,21 @@ module Form = {
         render={({field: {name, onBlur, onChange, ref, value}}) =>
           <div>
             <label> {name->React.string} </label>
-            <input name onBlur onChange ref value />
+            <input
+              name onBlur={_event => onBlur()} onChange={Controller.handleEvent(onChange)} ref value
+            />
+            <button
+              type_="button"
+              onClick={_event =>
+                onChange(
+                  Controller.OnChangeArg.value(
+                    Js.Json.string(
+                      value->Js.String2.split("")->Js.Array2.reverseInPlace->Js.Array2.joinWith(""),
+                    ),
+                  ),
+                )}>
+              {"Reverse"->React.string}
+            </button>
             <ErrorMessage errors name message={"Required"->React.string} />
           </div>}
       />
@@ -101,7 +119,14 @@ module Form = {
         render={({field: {name, onBlur, onChange, ref, value}}) => {
           <div>
             <label> {name->React.string} </label>
-            <input name onBlur onChange ref value type_="checkbox" />
+            <input
+              name
+              onBlur={_event => onBlur()}
+              onChange={Controller.handleEvent(onChange)}
+              ref
+              value
+              type_="checkbox"
+            />
           </div>
         }}
       />
@@ -117,7 +142,13 @@ module Form = {
                 render={({field: {name, onBlur, onChange, ref, value}}) =>
                   <div>
                     <label> {name->React.string} </label>
-                    <input name onBlur onChange ref value />
+                    <input
+                      name
+                      onBlur={_event => onBlur()}
+                      onChange={Controller.handleEvent(onChange)}
+                      ref
+                      value
+                    />
                     <ErrorMessage errors name message={"Required"->React.string} />
                     <button
                       type_="button"

--- a/example/Example.res
+++ b/example/Example.res
@@ -58,7 +58,11 @@ module Form = {
           <div>
             <label> {name->React.string} </label>
             <input
-              name onBlur={_event => onBlur()} onChange={Controller.handleEvent(onChange)} ref value
+              name
+              onBlur={_event => onBlur()}
+              onChange={event => onChange(Controller.OnChangeArg.event(event))}
+              ref
+              value
             />
             <span>
               {errors
@@ -83,7 +87,11 @@ module Form = {
           <div>
             <label> {name->React.string} </label>
             <input
-              name onBlur={_event => onBlur()} onChange={Controller.handleEvent(onChange)} ref value
+              name
+              onBlur={_event => onBlur()}
+              onChange={event => onChange(Controller.OnChangeArg.event(event))}
+              ref
+              value
             />
             <ErrorMessage errors name message={"Required"->React.string} />
           </div>}
@@ -96,7 +104,11 @@ module Form = {
           <div>
             <label> {name->React.string} </label>
             <input
-              name onBlur={_event => onBlur()} onChange={Controller.handleEvent(onChange)} ref value
+              name
+              onBlur={_event => onBlur()}
+              onChange={event => onChange(Controller.OnChangeArg.event(event))}
+              ref
+              value
             />
             <button
               type_="button"
@@ -122,7 +134,7 @@ module Form = {
             <input
               name
               onBlur={_event => onBlur()}
-              onChange={Controller.handleEvent(onChange)}
+              onChange={event => onChange(Controller.OnChangeArg.event(event))}
               ref
               value
               type_="checkbox"
@@ -145,7 +157,7 @@ module Form = {
                     <input
                       name
                       onBlur={_event => onBlur()}
-                      onChange={Controller.handleEvent(onChange)}
+                      onChange={event => onChange(Controller.OnChangeArg.event(event))}
                       ref
                       value
                     />

--- a/src/Controller.res
+++ b/src/Controller.res
@@ -21,32 +21,6 @@ This function allows you to set the input value to any arbitrary value.")
   let value = valueHandler => Any(valueHandler)
 }
 
-@ocaml.doc("Simple helper that simplifies `onChange` argument handling when it's passed down to native inputs.
-
-_Has a small runtime cost._
-
-Example:
-
-```
-<Controller
-  render={({field: {onChange}}) =>
-    <input onChange={event => onChange(Controller.OnChangeArg.event(event))} />
-  }
-/>
-```
-
-Can be written:
-
-```
-<Controller
-  render={({field: {onChange}}) =>
-    <input onChange={Controller.handleEvent(onChange)} />
-  }
-/>
-```
-")
-let handleEvent = (onChange, event) => onChange(OnChangeArg.event(event))
-
 @ocaml.doc(
   "The `field` object described [here](https://react-hook-form.com/api/usecontroller/controller#main)."
 )

--- a/src/Controller.res
+++ b/src/Controller.res
@@ -1,10 +1,59 @@
+module OnChangeArg: {
+  @@ocaml.doc(
+    "This module is used to build event or value argument to pass down to the `onChange` callback."
+  )
+
+  type rec t
+
+  @ocaml.doc("Takes a `ReactEvent.Form.t` and return an `onChange` argument.
+Useful for dealing with native form inputs.")
+  let event: ReactEvent.Form.t => t
+
+  @ocaml.doc("Takes a `Js.Json.t` and return an `onChange` argument.
+This function allows you to set the input value to any arbitrary value.")
+  let value: Js.Json.t => t
+} = {
+  @unboxed
+  type rec t = Any('a): t
+
+  let event = eventHandler => Any(eventHandler)
+
+  let value = valueHandler => Any(valueHandler)
+}
+
+@ocaml.doc("Simple helper that simplifies `onChange` argument handling when it's passed down to native inputs.
+
+_Has a small runtime cost._
+
+Example:
+
+```
+<Controller
+  render={({field: {onChange}}) =>
+    <input onChange={event => onChange(Controller.OnChangeArg.event(event))} />
+  }
+/>
+```
+
+Can be written:
+
+```
+<Controller
+  render={({field: {onChange}}) =>
+    <input onChange={Controller.handleEvent(onChange)} />
+  }
+/>
+```
+")
+let handleEvent = (onChange, event) => onChange(OnChangeArg.event(event))
+
 @ocaml.doc(
   "The `field` object described [here](https://react-hook-form.com/api/usecontroller/controller#main)."
 )
 type field = {
   name: string,
-  onBlur: ReactEvent.Focus.t => unit,
-  onChange: ReactEvent.Form.t => unit,
+  onBlur: unit => unit,
+  onChange: OnChangeArg.t => unit,
   ref: ReactDOM.domRef,
   // This is not correct, the value can be a bool or an int
   // The value should be considered opaque and never access directly

--- a/src/Validation.res
+++ b/src/Validation.res
@@ -1,9 +1,6 @@
-@ocaml.doc("
-This module is used to build sync function or async function for validate in Rules
-")
 @unboxed
 type rec t = Any('a): t
 
-let sync = (sync: string => bool) => Any(sync)
+let sync = syncHandler => Any(syncHandler)
 
-let async = (async: string => Js.Promise.t<bool>) => Any(async)
+let async = asyncHandler => Any(asyncHandler)

--- a/src/Validation.resi
+++ b/src/Validation.resi
@@ -1,5 +1,9 @@
+@@ocaml.doc("This module is used to build sync function or async function for validate in Rules.")
+
 type rec t
 
+@ocaml.doc("Synchronous validation")
 let sync: (string => bool) => t
 
+@ocaml.doc("Asynchronous validation")
 let async: (string => Js.Promise.t<bool>) => t


### PR DESCRIPTION
First pr related to the big refactor: *Improve the on* callback type signatures*

The new types are closer to the actual code and allows for more flexibility. Not only is `onChange` easier to call even without event, but it can now be used to update the value, no need for `setValue`!