### PR TITLE
Add the trigger function

### DIFF
--- a/example/Example.res
+++ b/example/Example.res
@@ -9,7 +9,7 @@ module Form = {
       reset,
       setFocus,
       setValue,
-    } = Hooks.Form.use(.
+    } as form = Hooks.Form.use(.
       ~config=Hooks.Form.config(
         ~mode=#onSubmit,
         ~defaultValues=Values.encoder({
@@ -209,6 +209,12 @@ module Form = {
         : React.null}
       <button type_="button" onClick={_event => append(. {"id": Uuid.v4(), "name": ""})}>
         {"Add hobby"->React.string}
+      </button>
+      <button type_="button" onClick={_event => form->Hooks.Form.trigger("email")}>
+        {"Validate email"->React.string}
+      </button>
+      <button type_="button" onClick={_event => form->Hooks.Form.triggerAndFocus("email")}>
+        {"Validate email and focus"->React.string}
       </button>
       <button
         type_="button" onClick={_event => setValue(. "firstName", ReCode.Encode.string("foo"))}>

--- a/src/Hooks.res
+++ b/src/Hooks.res
@@ -42,6 +42,13 @@ module Form = {
   @ocaml.doc("Bindings for the [useForm](https://react-hook-form.com/api/useform) hook.")
   @module("react-hook-form")
   external use: (. ~config: config=?, unit) => t = "useForm"
+
+  @send external trigger: (t, string) => unit = "trigger"
+
+  @send external triggerMultiple: (t, array<string>) => unit = "trigger"
+
+  @send
+  external triggerAndFocus: (t, string, @as(json`{ shouldFocus: true }`) _) => unit = "trigger"
 }
 
 module ArrayField = {


### PR DESCRIPTION
Implements https://react-hook-form.com/api/useform/trigger/

I used `@send external` instead of just adding it to the record to have more flexibility with no runtime costs. The API is a bit less consistent but more flexible. We could refactor records to use this technic too 😕 