### PR TITLE
Return an union type in Validation functions

### DIFF
--- a/example/Example.res
+++ b/example/Example.res
@@ -18,6 +18,7 @@ module Form = {
           "lastName": "",
           "acceptTerms": false,
           "hobbies": [{"name": ""}],
+          "location": "",
         }),
         (),
       ),
@@ -140,6 +141,30 @@ module Form = {
                 )}>
               {"Reverse"->React.string}
             </button>
+            <ErrorMessage errors name message={"Required"->React.string} />
+          </div>}
+      />
+      <Controller
+        name=Values.location
+        control
+        rules={Rules.make(
+          ~required=true,
+          ~validate=Js.Dict.fromArray([
+            ("minThreeChars", Validations.minThreeChars),
+            ("maxTenChars", Validations.maxTenChars),
+          ]),
+          (),
+        )}
+        render={({field: {name, onBlur, onChange, ref, value}}) =>
+          <div>
+            <label> {name->React.string} </label>
+            <input
+              name
+              onBlur={_event => onBlur()}
+              onChange={event => onChange(Controller.OnChangeArg.event(event))}
+              ref
+              value={value->ReCode.Decode.string->Belt.Result.getWithDefault("")}
+            />
             <ErrorMessage errors name message={"Required"->React.string} />
           </div>}
       />

--- a/example/Example.res
+++ b/example/Example.res
@@ -52,13 +52,17 @@ module Form = {
             (
               "validEmail",
               Validation.sync(value =>
-                value->ReCode.Decode.string->Belt.Result.getWithDefault("")->String.contains('@')
+                ValidationResult.boolResult(
+                  value->ReCode.Decode.string->Belt.Result.getWithDefault("")->String.contains('@'),
+                )
               ),
             ),
             (
               "validLength",
               Validation.sync(value =>
-                value->ReCode.Decode.string->Belt.Result.getWithDefault("")->String.length >= 8
+                ValidationResult.boolResult(
+                  value->ReCode.Decode.string->Belt.Result.getWithDefault("")->String.length >= 8,
+                )
               ),
             ),
           ]),

--- a/example/Validations.res
+++ b/example/Validations.res
@@ -1,0 +1,23 @@
+@ocaml.doc(
+  "Custom validator fuction to check that the input has at least three characters. Will return a boolean."
+)
+let minThreeCharsValue = value => {
+  let decodedValue = value->Js.Json.decodeString->Belt.Option.getWithDefault("")
+
+  ValidationResult.boolResult(decodedValue->Js.String2.length >= 3)
+}
+
+let minThreeChars = Validation.sync(minThreeCharsValue)
+
+@ocaml.doc(
+  "Custom validator fuction to check that the input has at most ten characters. Will throw a custom error otherwise."
+)
+let maxTenCharsValue = value => {
+  let decodedValue = value->Js.Json.decodeString->Belt.Option.getWithDefault("")
+
+  decodedValue->Js.String2.length > 10
+    ? ValidationResult.stringResult("There are over ten characters in this input.")
+    : ValidationResult.boolResult(true)
+}
+
+let maxTenChars = Validation.syncWithCustomError(maxTenCharsValue)

--- a/example/Values.res
+++ b/example/Values.res
@@ -23,6 +23,7 @@ type t = {
   email: string,
   firstName: string,
   lastName: string,
+  location: string,
   acceptTerms: bool,
   hobbies: array<Hobby.t>,
 }
@@ -30,14 +31,16 @@ type t = {
 let email = "email"
 let firstName = "firstName"
 let lastName = "lastName"
+let location = "location"
 let acceptTerms = "acceptTerms"
 let hobbies = "hobbies"
 let hobby = index => `${hobbies}.${index->Belt.Int.toString}.${Hobby.name}`
 
-let make = (email, firstName, lastName, acceptTerms, hobbies) => {
+let make = (email, firstName, lastName, acceptTerms, hobbies, location) => {
   email: email,
   firstName: firstName,
   lastName: lastName,
+  location: location,
   acceptTerms: acceptTerms,
   hobbies: hobbies,
 }
@@ -52,6 +55,7 @@ let decoder = {
   ->Object.required(lastName, string)
   ->Object.required(acceptTerms, bool)
   ->Object.required(hobbies, array(Hobby.decoder))
+  ->Object.required(location, string)
 }
 
 let encoder = values => {
@@ -61,6 +65,7 @@ let encoder = values => {
     (email, string(values["email"])),
     (firstName, string(values["firstName"])),
     (lastName, string(values["lastName"])),
+    (location, string(values["location"])),
     (acceptTerms, bool(values["acceptTerms"])),
     (hobbies, array(Hobby.encoder, values["hobbies"])),
   ])

--- a/src/Validation.res
+++ b/src/Validation.res
@@ -3,4 +3,8 @@ type rec t = Any('a): t
 
 let sync = syncHandler => Any(syncHandler)
 
+let syncWithCustomError = syncHandler => Any(syncHandler)
+
 let async = asyncHandler => Any(asyncHandler)
+
+let asyncWithCustomError = asyncHandler => Any(asyncHandler)

--- a/src/Validation.resi
+++ b/src/Validation.resi
@@ -3,7 +3,11 @@
 type rec t
 
 @ocaml.doc("Synchronous validation")
-let sync: (Js.Json.t => bool) => t
+let sync: (Js.Json.t => ValidationResult.t) => t
+
+let syncWithCustomError: (Js.Json.t => ValidationResult.t) => t
 
 @ocaml.doc("Asynchronous validation")
-let async: (Js.Json.t => Js.Promise.t<bool>) => t
+let async: (Js.Json.t => Js.Promise.t<ValidationResult.t>) => t
+
+let asyncWithCustomError: (Js.Json.t => Js.Promise.t<ValidationResult.t>) => t

--- a/src/ValidationResult.res
+++ b/src/ValidationResult.res
@@ -1,0 +1,5 @@
+@unboxed type rec t = Any('value): t
+
+let boolResult = validationResult => Any(validationResult)
+
+let stringResult = validationResult => Any(validationResult)

--- a/src/ValidationResult.resi
+++ b/src/ValidationResult.resi
@@ -1,0 +1,8 @@
+@ocaml.doc(
+  "The union type for the result of a validator function;  allows validation functions to return either boolean or a string"
+)
+type rec t
+
+let boolResult: bool => t
+
+let stringResult: string => t


### PR DESCRIPTION
### The issue

Our custom validation function need to be able to return custom error messages in case the input value is invalid.


### The fix
In order to return custom error messages, we need to enable our custom validation function to return either a boolean or a string instead of a falsy value. I've created a new union type and i've updated the Example in this repository with a couple of validation functions, one of which will return a custom error message string. 


<img width="778" alt="Screen Shot 2022-08-10 at 14 21 00" src="https://user-images.githubusercontent.com/18513968/183822522-0c76d98a-cc09-4e73-bc72-ac4f5dcfd0fd.png">
<img width="747" alt="Screen Shot 2022-08-10 at 14 20 52" src="https://user-images.githubusercontent.com/18513968/183822531-04ab68a9-eba4-47f9-a712-eb1d8f37d0c5.png">

